### PR TITLE
Add Next.js rental car skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# codex-dev
-# codex-dev
+# Rent Car Management (Next.js)
+
+기본적인 렌트카 관리 프로그램 예시입니다. 주요 폴더 구조는 아래와 같습니다.
+
+```
+app/
+  layout.tsx          # 공통 레이아웃
+  page.tsx            # 홈 페이지
+  cars/               # 차량 목록 페이지
+  api/
+    cars/             # 차량 API 라우트
+      route.ts        # GET, POST
+      [id]/route.ts   # PUT, DELETE
+lib/
+  prisma.ts           # Prisma 클라이언트
+  auth.ts             # 사용자 역할 확인 예시
+prisma/
+  schema.prisma       # 데이터베이스 스키마
+```
+
+TailwindCSS와 TypeScript를 사용하며, Prisma로 DB 모델을 정의합니다.

--- a/app/api/cars/[id]/route.ts
+++ b/app/api/cars/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserRole } from '@/lib/auth';
+
+type Params = { params: { id: string } };
+
+export async function PUT(request: Request, { params }: Params) {
+  const role = await getUserRole();
+  if (role !== 'admin' && role !== 'staff') {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const data = await request.json();
+  const car = await prisma.car.update({
+    where: { id: Number(params.id) },
+    data,
+  });
+  return NextResponse.json(car);
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+  const role = await getUserRole();
+  if (role !== 'admin' && role !== 'staff') {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  await prisma.car.delete({ where: { id: Number(params.id) } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserRole } from '@/lib/auth';
+
+export async function GET() {
+  const cars = await prisma.car.findMany();
+  return NextResponse.json(cars);
+}
+
+export async function POST(request: Request) {
+  const role = await getUserRole();
+  if (role !== 'admin' && role !== 'staff') {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const data = await request.json();
+  const car = await prisma.car.create({ data });
+  return NextResponse.json(car, { status: 201 });
+}

--- a/app/cars/page.tsx
+++ b/app/cars/page.tsx
@@ -1,0 +1,40 @@
+const cars = [
+  {
+    id: 1,
+    brand: 'Hyundai',
+    model: 'Sonata',
+    plate: '12가3456',
+    status: 'available',
+    dailyRate: 50000,
+  },
+];
+
+export default function CarsPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">차량 목록</h1>
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left text-sm font-semibold text-gray-900">브랜드</th>
+            <th className="px-3 py-2 text-left text-sm font-semibold text-gray-900">모델</th>
+            <th className="px-3 py-2 text-left text-sm font-semibold text-gray-900">번호판</th>
+            <th className="px-3 py-2 text-left text-sm font-semibold text-gray-900">상태</th>
+            <th className="px-3 py-2 text-left text-sm font-semibold text-gray-900">일일 요금</th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {cars.map((car) => (
+            <tr key={car.id}>
+              <td className="px-3 py-2 whitespace-nowrap">{car.brand}</td>
+              <td className="px-3 py-2 whitespace-nowrap">{car.model}</td>
+              <td className="px-3 py-2 whitespace-nowrap">{car.plate}</td>
+              <td className="px-3 py-2 whitespace-nowrap">{car.status}</td>
+              <td className="px-3 py-2 whitespace-nowrap">{car.dailyRate.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,12 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ko">
+      <body className="min-h-screen bg-gray-100">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">렌트카 관리 프로그램</h1>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,9 @@
+import { headers } from 'next/headers';
+
+// Example helper to get user role from a JWT token
+export async function getUserRole(): Promise<string | null> {
+  const token = headers().get('authorization')?.replace('Bearer ', '');
+  if (!token) return null;
+  // TODO: decode token and extract role
+  return 'admin'; // placeholder
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const role = request.headers.get('x-role');
+  if (request.nextUrl.pathname.startsWith('/admin') && role !== 'admin') {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "rentcar-app",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@prisma/client": "latest",
+    "next": "13.4.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "prisma": "latest",
+    "tailwindcss": "latest",
+    "typescript": "5.0.0"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,69 @@
+datasource db {
+  provider = "postgresql" // or mysql
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id            Int           @id @default(autoincrement())
+  name          String
+  email         String        @unique
+  phone         String?
+  role          Role          @default(customer)
+  reservations  Reservation[]
+  payments      Payment[]
+}
+
+enum Role {
+  admin
+  staff
+  customer
+}
+
+model Car {
+  id           Int        @id @default(autoincrement())
+  brand        String
+  model        String
+  plate        String     @unique
+  status       CarStatus  @default(available)
+  dailyRate    Float
+  reservations Reservation[]
+}
+
+enum CarStatus {
+  available
+  rented
+  maintenance
+}
+
+model Reservation {
+  id         Int                @id @default(autoincrement())
+  car        Car                @relation(fields: [carId], references: [id])
+  carId      Int
+  user       User               @relation(fields: [userId], references: [id])
+  userId     Int
+  startDate  DateTime
+  endDate    DateTime
+  totalPrice Float
+  status     ReservationStatus  @default(pending)
+  payment    Payment?
+}
+
+enum ReservationStatus {
+  pending
+  confirmed
+  cancelled
+  completed
+}
+
+model Payment {
+  id            Int       @id @default(autoincrement())
+  reservation   Reservation @relation(fields: [reservationId], references: [id])
+  reservationId Int
+  method        String
+  amount        Float
+  timestamp     DateTime   @default(now())
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up basic Next.js project structure with TypeScript
- add Prisma schema for cars, users, reservations and payments
- implement car listing page with Tailwind
- create REST API routes for car CRUD operations
- add simple role based middleware example

## Testing
- `git status --short`